### PR TITLE
[bugfix] support no-whitespace alert expressions in instance filtering

### DIFF
--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorTest.java
@@ -1,0 +1,83 @@
+package org.apache.hertzbeat.alert.calculate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.hertzbeat.alert.AlerterWorkerPool;
+import org.apache.hertzbeat.alert.dao.SingleAlertDao;
+import org.apache.hertzbeat.alert.reduce.AlarmCommonReduce;
+import org.apache.hertzbeat.alert.service.AlertDefineService;
+import org.apache.hertzbeat.common.entity.alerter.AlertDefine;
+import org.apache.hertzbeat.common.queue.CommonDataQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+class RealTimeAlertCalculatorTest {
+
+    private RealTimeAlertCalculator calculator;
+
+    @BeforeEach
+    void setUp() {
+        AlerterWorkerPool mockPool = Mockito.mock(AlerterWorkerPool.class);
+        CommonDataQueue mockQueue = Mockito.mock(CommonDataQueue.class);
+        AlertDefineService mockAlertDefineService = Mockito.mock(AlertDefineService.class);
+        SingleAlertDao mockDao = Mockito.mock(SingleAlertDao.class);
+        AlarmCommonReduce mockReduce = Mockito.mock(AlarmCommonReduce.class);
+        AlarmCacheManager alarmCacheManager = Mockito.mock(AlarmCacheManager.class);
+
+        Mockito.when(mockDao.querySingleAlertsByStatus(Mockito.anyString()))
+                .thenReturn(Collections.emptyList());
+
+        calculator = new RealTimeAlertCalculator(mockPool, mockQueue, mockAlertDefineService, mockDao, mockReduce, alarmCacheManager, false);
+    }
+
+    @Test
+    void testFilterThresholdsByAppAndMetrics_withInstanceExpr_HasSpace() {
+        String app = "redis";
+        String instanceId = "501045327364864";
+        int priority = 0;
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__, \"501045327364864\")");
+
+        AlertDefine unmatchDefine = new AlertDefine();
+        unmatchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__, \"999999999\")");
+
+        List<AlertDefine> allDefines = Arrays.asList(matchDefine, unmatchDefine);
+
+        List<AlertDefine> filtered = calculator.filterThresholdsByAppAndMetrics(allDefines, app, "", Map.of(), instanceId, priority);
+
+        // It should filter out 999999999.
+        assertEquals(1, filtered.size());
+        assertEquals("equals(__app__,\"redis\") && equals(__instance__, \"501045327364864\")",
+                filtered.get(0).getExpr());
+    }
+
+    @Test
+    void testFilterThresholdsByAppAndMetrics_withInstanceExpr_NoSpace() {
+        String app = "redis";
+        String instanceId = "501045327364864";
+        int priority = 0;
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__,\"501045327364864\")");
+
+        AlertDefine unmatchDefine = new AlertDefine();
+        unmatchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__,\"999999999\")");
+
+        List<AlertDefine> allDefines = Arrays.asList(matchDefine, unmatchDefine);
+
+        List<AlertDefine> filtered = calculator.filterThresholdsByAppAndMetrics(allDefines, app, "", Map.of(), instanceId, priority);
+
+        // It should filter out 999999999.
+        assertEquals(1, filtered.size());
+        assertEquals("equals(__app__,\"redis\") && equals(__instance__,\"501045327364864\")",
+                filtered.get(0).getExpr());
+    }
+}


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
#3220 

This PR fixes a bug in RealTimeAlertCalculator where instance filtering failed when alert expressions contained no whitespace (e.g., `equals(__app__,"redis") && equals(__instance__,"501045327364864")`).

The backend regex has been updated to support such compact expressions. A unit test is also added to ensure proper filtering across different formatting styles.

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [X]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to instantiate alert calculation without automatically starting calculation threads.
- **Bug Fixes**
  - Improved instance pattern matching to handle optional whitespace in alert definitions.
- **Tests**
  - Introduced new tests to verify correct filtering of alert definitions based on instance ID expressions, covering cases with and without spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->