### PR TITLE
[improve] Add jdbc common collect e2e code (#3273)

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/database/JdbcCommonCollect.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/database/JdbcCommonCollect.java
@@ -383,6 +383,8 @@ public class JdbcCommonCollect extends AbstractCollect {
             case "oracle" -> "jdbc:oracle:thin:@" + host + ":" + port
                     + "/" + (jdbcProtocol.getDatabase() == null ? "" : jdbcProtocol.getDatabase());
             case "dm" -> "jdbc:dm://" + host + ":" + port;
+            case "testcontainers" -> "jdbc:tc:" + host + ":" + port
+                    + ":///" + (jdbcProtocol.getDatabase() == null ? "" : jdbcProtocol.getDatabase()) + "?user=root&password=root";
             default -> throw new IllegalArgumentException("Not support database platform: " + jdbcProtocol.getPlatform());
         };
     }

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/pom.xml
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/pom.xml
@@ -96,6 +96,5 @@
             <optional>true</optional>
         </dependency>
 
-
     </dependencies>
 </project>

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/pom.xml
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/pom.xml
@@ -31,6 +31,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mysql.version>8.0.30</mysql.version>
+        <postgresql.version>42.5.5</postgresql.version>
     </properties>
 
     <dependencies>
@@ -53,10 +55,47 @@
             <version>${hertzbeat.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Testcontainers Jupiter / JUnit 5 -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Testcontainers JDBC Support -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Testcontainers Database Modules -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JDBC Drivers -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.version}</version>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
+
+
     </dependencies>
 </project>

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hertzbeat.collector.collect.basic.database;
 
 public enum DatabaseImagesEnum {

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
@@ -17,6 +17,9 @@
 
 package org.apache.hertzbeat.collector.collect.basic.database;
 
+/**
+ * Database type (image mame) and image tag enumeration class
+ */
 public enum DatabaseImagesEnum {
     MYSQL("mysql", "8.0.36"),
     POSTGRESQL("postgresql", "15");

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/DatabaseImagesEnum.java
@@ -1,0 +1,52 @@
+package org.apache.hertzbeat.collector.collect.basic.database;
+
+public enum DatabaseImagesEnum {
+    MYSQL("mysql", "8.0.36"),
+    POSTGRESQL("postgresql", "15");
+
+    private final String imageName;
+    private final String defaultTag;
+
+    DatabaseImagesEnum(String imageName, String defaultTag) {
+        this.imageName = imageName;
+        this.defaultTag = defaultTag;
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+
+    public String getDefaultTag() {
+        return defaultTag;
+    }
+
+    public String getFullImageName() {
+        return imageName + ":" + defaultTag;
+    }
+
+    public static DatabaseImagesEnum fromImageName(String imageName) {
+        for (DatabaseImagesEnum value : values()) {
+            if (value.getImageName().equalsIgnoreCase(imageName)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unknown database image name: " + imageName);
+    }
+
+    public static DatabaseImagesEnum fromFullImageName(String fullImageName) {
+        for (DatabaseImagesEnum value : values()) {
+            if (value.getFullImageName().equalsIgnoreCase(fullImageName)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Unknown full database image name: " + fullImageName);
+    }
+
+    @Override
+    public String toString() {
+        return "DatabaseImageNameEnum{" +
+                "imageName='" + imageName + '\'' +
+                ", defaultTag='" + defaultTag + '\'' +
+                '}';
+    }
+}

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hertzbeat.collector.collect.basic.database;
 
 import lombok.extern.slf4j.Slf4j;

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
@@ -39,6 +39,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+/**
+ * E2e test monitored by Jdbc Common
+ */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 public class JdbcCommonCollectE2eTest extends AbstractCollectE2eTest {

--- a/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
+++ b/hertzbeat-e2e/hertzbeat-collector-basic-e2e/src/test/java/org/apache/hertzbeat/collector/collect/basic/database/JdbcCommonCollectE2eTest.java
@@ -1,0 +1,79 @@
+package org.apache.hertzbeat.collector.collect.basic.database;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hertzbeat.collector.collect.AbstractCollectE2eTest;
+import org.apache.hertzbeat.collector.collect.database.JdbcCommonCollect;
+import org.apache.hertzbeat.collector.util.CollectUtil;
+import org.apache.hertzbeat.common.entity.job.Configmap;
+import org.apache.hertzbeat.common.entity.job.Job;
+import org.apache.hertzbeat.common.entity.job.Metrics;
+import org.apache.hertzbeat.common.entity.job.protocol.JdbcProtocol;
+import org.apache.hertzbeat.common.entity.job.protocol.Protocol;
+import org.apache.hertzbeat.common.entity.message.CollectRep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class JdbcCommonCollectE2eTest extends AbstractCollectE2eTest {
+    private static final DatabaseImagesEnum databaseImage = DatabaseImagesEnum.fromImageName("postgresql");
+
+    private static final String DATABASE_IMAGE_NAME = databaseImage.getImageName();
+
+    private static final String DATABASE_IMAGE_TAG = databaseImage.getDefaultTag();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        collect = new JdbcCommonCollect();
+        metrics = new Metrics();
+    }
+
+    @Override
+    protected CollectRep.MetricsData.Builder collectMetrics(Metrics metricsDef) {
+        JdbcProtocol jdbcProtocol = (JdbcProtocol) buildProtocol(metricsDef);
+        metrics.setJdbc(jdbcProtocol);
+        CollectRep.MetricsData.Builder metricsData = CollectRep.MetricsData.newBuilder();
+        metricsData.setApp(DATABASE_IMAGE_NAME);
+        metrics.setAliasFields(metricsDef.getAliasFields());
+        return collectMetricsData(metrics, metricsDef, metricsData);
+    }
+
+    @Override
+    protected Protocol buildProtocol(Metrics metricsDef) {
+        JdbcProtocol jdbcProtocol = metricsDef.getJdbc();
+        jdbcProtocol.setHost(DATABASE_IMAGE_NAME);
+        jdbcProtocol.setPort(DATABASE_IMAGE_TAG);
+        jdbcProtocol.setDatabase("test");
+        jdbcProtocol.setPlatform("testcontainers");
+        return jdbcProtocol;
+    }
+
+    @Test
+    public void testWithJdbcTcUrl() {
+        Job dockerJob = appService.getAppDefine(DATABASE_IMAGE_NAME);
+        List<Map<String, Configmap>> configmapFromPreCollectData = new LinkedList<>();
+        for (Metrics metricsDef : dockerJob.getMetrics()) {
+            metricsDef = CollectUtil.replaceCryPlaceholderToMetrics(metricsDef, configmapFromPreCollectData.size() > 0 ? configmapFromPreCollectData.get(0) : new HashMap<>());
+            String metricName = metricsDef.getName();
+            if ("slow_sql".equals(metricName)) {
+                Metrics finalMetricsDef = metricsDef;
+                assertDoesNotThrow(() -> collectMetrics(finalMetricsDef),
+                        String.format("%s failed to collect metrics)", metricName));
+                log.info("{} metrics validation passed", metricName);
+                continue;  // skip slow_sql, extra extensions
+            }
+            CollectRep.MetricsData metricsData = validateMetricsCollection(metricsDef, metricName, true);
+            CollectUtil.getConfigmapFromPreCollectData(metricsData);
+        }
+    }
+}

--- a/hertzbeat-e2e/pom.xml
+++ b/hertzbeat-e2e/pom.xml
@@ -74,4 +74,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
Benefit from testcontainers' rich jdbc driver support (SPI implementation), add jdbc common collect e2e code (postgresql/mysql supported for now)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for constructing JDBC URLs for "testcontainers" database platforms.
  - Introduced a new enum for managing database image types and default tags.
  - Added end-to-end tests for collecting metrics from PostgreSQL databases running in test containers.

- **Chores**
  - Updated project dependencies to support database testing with Testcontainers, including centralized version management and new test-scoped dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->